### PR TITLE
Per-word bounding region fetching

### DIFF
--- a/react-pdf-sample/src/Mocks.ts
+++ b/react-pdf-sample/src/Mocks.ts
@@ -69,7 +69,7 @@ export const mockCitations: Citation[][] = [
   // "What is a quote that spans two pages?"
   [
     {
-      excerpt: "Our revenue fluctuates quarterly and is generally higher in the second and fourth quarters of our fiscal year. Second quarter revenue is driven by corporate year-end spending trends in our major markets and holiday season spending by consumers, and fourth quarter revenue is driven by the volume of multi-year on-premises contracts executed during the period.\nReportable Segments",
+      excerpt: "Our revenue fluctuates quarterly and is generally higher in the second and fourth quarters of our fiscal year. Second quarter revenue is driven by corporate year-end spending trends in our major markets and holiday season spending by consumers, and fourth quarter revenue is driven by the volume of multi-year on-premises contracts executed during the period.",
       docIndex: 1,
       reviewStatus: 0,
     },

--- a/react-pdf-sample/src/Utility.ts
+++ b/react-pdf-sample/src/Utility.ts
@@ -145,6 +145,7 @@ const fuzzyMatch = (line: string, subline: string, threshold = 0.6) => {
 // special cases:
 //  - case is irrelevant
 //  - strip trailing periods
+//  - strip trailing semicolons
 //  - strip dollar signs
 const match = (
   str0: string,

--- a/react-pdf-sample/src/Utility.ts
+++ b/react-pdf-sample/src/Utility.ts
@@ -172,6 +172,8 @@ const match = (
   return false;
 }
 
+// Given a docint response and reference text (array of words), find
+// the relevant BoundingRegions (per-word)
 const findBoundingRegions = (
   text: string[],
   response: DocumentIntelligenceResponse

--- a/react-pdf-sample/src/Utility.ts
+++ b/react-pdf-sample/src/Utility.ts
@@ -142,13 +142,29 @@ const fuzzyMatch = (line: string, subline: string, threshold = 0.6) => {
 };
 
 // Simple matching
-// only special case at current: it strips trailing periods
+// special cases:
+//  - case is irrelevant
+//  - strip trailing periods
+//  - strip dollar signs
 const match = (
   str0: string,
   str1: string
 ) => {
+  // lower case
+  str0 = str0.toLocaleLowerCase();
+  str1 = str1.toLocaleLowerCase();
+
+  // Strip trailing periods
   if (str0.slice(-1) == '.') str0 = str0.slice(0, -1);
   if (str1.slice(-1) == '.') str1 = str1.slice(0, -1);
+
+  // Strip trailing semicolons
+  if (str0.slice(-1) == ';') str0 = str0.slice(0, -1);
+  if (str1.slice(-1) == ';') str1 = str1.slice(0, -1);
+
+  // strip dollar signs
+  if (str0.slice(0,1) == '$') str0 = str0.slice(1);
+  if (str1.slice(0,1) == '$') str1 = str1.slice(1);
 
   if (str0 === str1) return true;
 
@@ -226,7 +242,7 @@ export const returnTextPolygonsFromDI = (
     console.log("NO MATCH:", words);
     return;
   }
-  console.log("MATCH:", words)
+  console.log("MATCH:", words);
   return boundingRegions;
   // what happens if we don't find any bounding regions?
   // The question exists, the reference exists, the document exists, Document Intelligence just didn't do its job

--- a/react-pdf-sample/src/Utility.ts
+++ b/react-pdf-sample/src/Utility.ts
@@ -9,7 +9,7 @@ const round = (value: number, precision = 0) => {
 // Return true if polygons overlap (ncluding sharing borders); false otherwise
 // delta controls the amount of space that can be between polygons without them
 // being considered non-adjacent (i.e. accounts for spaces between words)
-const adjacent = (poly0: number[], poly1: number[], delta = 0.1) => {
+const adjacent = (poly0: number[], poly1: number[], delta = 0.2) => {
   const x0 = [round(poly0[0], 1), round(poly0[2], 1)];
   const y0 = [round(poly0[1], 1), round(poly0[5], 1)];
 


### PR DESCRIPTION
Fetches boundingRegions per-word rather than per-line or per-paragraph.

Hard to be sure it's working right because the boundingRegions are drawn incorrectly on my machine, but everything's being found now.

Special cases for matching: I strip off starting `$`, trailing `;` or `.` based on our sample excerpts.