### PR TITLE
Refinement - some cleanup to the other day's changes

### DIFF
--- a/function-sample/src/functions/post.ts
+++ b/function-sample/src/functions/post.ts
@@ -43,7 +43,7 @@ async function updateCitationReview(citation_id: number, review: Review) {
 // Inserts into db events table
 async function insertAddEvent(form_id: number, question_id: number, document_id: number, citation_id: number, excerpt: string, bounds: BoundingRegion[], review: ReviewStatus, creator: string) {
   return db.insert(events).values({
-    type: 'add',
+    type: 'addCitation',
     form_id,
     question_id,
     document_id,
@@ -56,9 +56,9 @@ async function insertAddEvent(form_id: number, question_id: number, document_id:
 }
 
 // Inserts into db events table
-async function insertReviewEvent(citation_id: number, review: Review, creator: string) {
+async function insertUpdateReviewEvent(citation_id: number, review: Review, creator: string) {
   return db.insert(events).values({
-    type: 'review',
+    type: 'updateReview',
     citation_id,
     review,
     creator
@@ -66,9 +66,9 @@ async function insertReviewEvent(citation_id: number, review: Review, creator: s
 }
 
 // Inserts into db events table
-async function insertUpdateEvent(citation_id: number, bounds: BoundingRegion[], creator: string) {
+async function insertUpdateBoundsEvent(citation_id: number, bounds: BoundingRegion[], creator: string) {
   return db.insert(events).values({
-    type: 'update',
+    type: 'updateBounds',
     citation_id,
     bounds,
     creator
@@ -92,7 +92,7 @@ async function addCitation(context: InvocationContext, form_id: number, question
 async function addReview(context: InvocationContext, citation_id: number, review: Review, creator: string) {
   const citation = await updateCitationReview(citation_id, review);
   context.log("Updated citation:", citation);
-  const event = await insertReviewEvent(citation_id, review, creator);
+  const event = await insertUpdateReviewEvent(citation_id, review, creator);
   context.log("Created event:", event);
 }
 
@@ -100,7 +100,7 @@ async function addReview(context: InvocationContext, citation_id: number, review
 async function updateBounds(context: InvocationContext, citation_id: number, bounds: BoundingRegion[], creator: string) {
   let citation = await updateCitationBounds(citation_id, bounds);
   context.log("Updated citation:", citation);
-  let event = await insertUpdateEvent(citation_id, bounds, creator);
+  let event = await insertUpdateBoundsEvent(citation_id, bounds, creator);
   context.log("Created event:", event);
 }
 

--- a/function-sample/src/functions/post.ts
+++ b/function-sample/src/functions/post.ts
@@ -110,7 +110,9 @@ async function insertUpdateBoundsEvent(citation_id: number, bounds: BoundingRegi
 // event handling
 // ============================================================================
 
-// Adding a citation involves creating a new citation and a new event
+// Adding a citation involves:
+//  - creating a new citation
+//  - creating a new event
 async function addCitation(context: InvocationContext, form_id: number, question_id: number, document_id: number, excerpt: string, bounds: BoundingRegion[], review: Review, creator: string) {
   let citation = await insertCitation(form_id, question_id, document_id, excerpt, bounds, review, creator);
   context.log("Created citation:", citation);
@@ -119,7 +121,9 @@ async function addCitation(context: InvocationContext, form_id: number, question
   context.log("Created event:", event);
 }
 
-// Adding a review involves creating a new event
+// Adding a review involves:
+//  - updating an existing citation
+//  - creating a new event
 async function addReview(context: InvocationContext, citation_id: number, review: Review, creator: string) {
   const citation = await updateCitationReview(citation_id, review);
   context.log("Updated citation:", citation);
@@ -127,7 +131,9 @@ async function addReview(context: InvocationContext, citation_id: number, review
   context.log("Created event:", event);
 }
 
-// Updating bounds data involves updating an existing citation
+// Updating bounds data involves:
+//  - updating an existing citation
+//  - creating a new event
 async function updateBounds(context: InvocationContext, citation_id: number, bounds: BoundingRegion[], creator: string) {
   let citation = await updateCitationBounds(citation_id, bounds);
   context.log("Updated citation:", citation);

--- a/function-sample/src/functions/post.ts
+++ b/function-sample/src/functions/post.ts
@@ -31,13 +31,21 @@ async function updateCitationBounds(citation_id: number, bounds: BoundingRegion[
   return db.update(citations).set({
     bounds,
     bounds_created_at: sql`now()`
-  }).where(eq(citations.id, citation_id)).returning();
+  }).where(eq(citations.id, citation_id)).returning({
+    id: citations.id,
+    excerpt: citations.excerpt,
+    bounds: citations.bounds
+  });
 }
 
 async function updateCitationReview(citation_id: number, review: Review) {
   return db.update(citations).set({
     review
-  }).where(eq(citations.id, citation_id)).returning();
+  }).where(eq(citations.id, citation_id)).returning({
+    id: citations.id,
+    excerpt: citations.excerpt,
+    review: citations.review
+  });
 }
 
 // Inserts into db events table
@@ -52,7 +60,18 @@ async function insertAddEvent(form_id: number, question_id: number, document_id:
     bounds,
     review,
     creator
-  }).returning();
+  }).returning({
+    type: events.type,
+    form_id: events.form_id,
+    question_id: events.question_id,
+    document_id: events.document_id,
+    citation_id: events.citation_id,
+    excerpt: events.excerpt,
+    bounds: events.bounds,
+    review: events.review,
+    creator: events.creator,
+    created_at: events.created_at
+  });
 }
 
 // Inserts into db events table
@@ -62,7 +81,13 @@ async function insertUpdateReviewEvent(citation_id: number, review: Review, crea
     citation_id,
     review,
     creator
-  }).returning();
+  }).returning({
+    type: events.type,
+    citation_id: events.citation_id,
+    review: events.review,
+    creator: events.creator,
+    created_at: events.created_at
+  });
 }
 
 // Inserts into db events table
@@ -72,7 +97,13 @@ async function insertUpdateBoundsEvent(citation_id: number, bounds: BoundingRegi
     citation_id,
     bounds,
     creator
-  }).returning();
+  }).returning({
+    type: events.type,
+    citation_id: events.citation_id,
+    bounds: events.bounds,
+    creator: events.creator,
+    created_at: events.created_at
+  });
 }
 
 // ============================================================================

--- a/function-sample/src/functions/post.ts
+++ b/function-sample/src/functions/post.ts
@@ -20,7 +20,6 @@ async function insertCitation(form_id: number, question_id: number, document_id:
     document_id,
     excerpt,
     bounds,
-    bounds_created_at: sql`now()`,
     review,
     creator
   }).returning();
@@ -30,7 +29,6 @@ async function insertCitation(form_id: number, question_id: number, document_id:
 async function updateCitationBounds(citation_id: number, bounds: BoundingRegion[]) {
   return db.update(citations).set({
     bounds,
-    bounds_created_at: sql`now()`
   }).where(eq(citations.id, citation_id)).returning({
     id: citations.id,
     excerpt: citations.excerpt,

--- a/function-sample/src/schema.ts
+++ b/function-sample/src/schema.ts
@@ -41,7 +41,6 @@ export const citations = pgTable('citations', {
   document_id: integer('document_id').notNull(),
   excerpt: text('excerpt').notNull(),
   bounds: jsonb('bounds'),
-  bounds_created_at: timestamp('bounds_created_at'),
   review: text('review').notNull().default('Unreviewed'),
   creator: text('creator').notNull(),
   created_at: timestamp('created_at').notNull().defaultNow()

--- a/postgres-sample/create.sql
+++ b/postgres-sample/create.sql
@@ -41,7 +41,6 @@ CREATE TABLE citations (
   document_id INTEGER NOT NULL,
   excerpt TEXT NOT NULL,
   bounds JSONB,
-  bounds_created_at TIMESTAMP,
   review TEXT NOT NULL DEFAULT 'Unreviewed',
   creator TEXT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()


### PR DESCRIPTION
- Remove `bounds_created_at` from SQL/fn samples as discussed
- Fix some renaming regarding add/addCitations//update/updateBounds//review/updateReview
- some crisper comments and logging