### PR TITLE
Lighter icons

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -23,6 +23,9 @@
   --color-approve: #00ac00;
   --color-reject: #f07070;
   --color-highlight: #00acdc;
+  --color-edit: #ffa500;
+
+  --color-icon: light-dark(#808080, #b6b6b6);
 
   --rounding-height: 3px;
 
@@ -340,17 +343,15 @@ button:focus-visible {
 }
 
 .citation-icon {
-  pointer-events: all;
-
   &.approved {
     &.on {
       color: var(--color-approve);
       :hover {
-        color: var(--color-button-enabled);
+        color: var(--color-icon);
       }
     }
     &.off {
-      color: var(--color-button-enabled);
+      color: var(--color-icon);
       :hover {
         color: var(--color-approve);
       }
@@ -360,11 +361,11 @@ button:focus-visible {
     &.on {
       color: var(--color-reject);
       :hover {
-        color: var(--color-button-enabled);
+        color: var(--color-icon);
       }
     }
     &.off {
-      color: var(--color-button-enabled);
+      color: var(--color-icon);
       :hover {
         color: var(--color-reject);
       }
@@ -373,20 +374,24 @@ button:focus-visible {
   &.unreviewed {
     color: var(--color-highlight);
   }
-  &.edit {
-    color: var(--color-button-enabled);
+  &.edit-start {
+    color: var(--color-icon);
     :hover {
-      color: var(--color-button-hover);
+      color: var(--color-edit);
     }
   }
-}
-
-.edit-icon {
-  height: 100%;
-  width: 100%;
-  color: var(--color-button-enabled);
-  &:hover {
-    color: var(--color-button-hover);
+  &.edit-cancel {
+    grid-column: 5;
+    color: var(--color-icon);
+    :hover {
+      color: black;
+    }    
+  }
+  &.edit-save {
+    color: var(--color-icon);
+    :hover {
+      color: black;
+    }
   }
 }
 
@@ -409,6 +414,25 @@ button:focus-visible {
 .icon {
   height: 100%;
   width: 100%;
+  pointer-events: all;
+}
+
+.hoverable {
+  .filled {
+    display: none;
+  }
+  .regular {
+    display: block;
+  }
+  &:hover {
+    cursor: pointer;
+    .filled {
+      display: block;
+    }
+    .regular {
+      display: none;
+    }
+  }
 }
 
 .buttons {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -24,6 +24,7 @@
   --color-reject: #f07070;
   --color-highlight: #00acdc;
   --color-edit: #ffa500;
+  --color-edit-hover: black;
 
   --color-icon: light-dark(#808080, #b6b6b6);
 
@@ -257,6 +258,7 @@ button:focus-visible {
     color: var(--color-text-page-active);
   }
   &.unselected:hover {
+    cursor: pointer;
     background-color: var(--color-page-hover);
     .top-right {
       div {
@@ -309,6 +311,7 @@ button:focus-visible {
     }
   }
   &.unselected:hover {
+    cursor: pointer;
     .citation-excerpt {
       border-radius: 4px;
       border-color: var(--color-highlight);
@@ -333,7 +336,7 @@ button:focus-visible {
       resize: none;
       font-family: inherit;
       font-size: 100%;
-      margin: -2px 0 -4px -2px;
+      margin: -2px 0 -9px -2px;
       outline: none;
     }
     .editor-cancel {
@@ -343,6 +346,7 @@ button:focus-visible {
 }
 
 .citation-icon {
+  color: var(--color-icon);
   &.approved {
     &.on {
       color: var(--color-approve);
@@ -351,7 +355,6 @@ button:focus-visible {
       }
     }
     &.off {
-      color: var(--color-icon);
       :hover {
         color: var(--color-approve);
       }
@@ -365,7 +368,6 @@ button:focus-visible {
       }
     }
     &.off {
-      color: var(--color-icon);
       :hover {
         color: var(--color-reject);
       }
@@ -375,23 +377,39 @@ button:focus-visible {
     color: var(--color-highlight);
   }
   &.edit-start {
-    color: var(--color-icon);
     :hover {
       color: var(--color-edit);
     }
   }
   &.edit-cancel {
     grid-column: 5;
-    color: var(--color-icon);
     :hover {
-      color: black;
-    }    
+      color: var(--color-edit-hover);
+    }
   }
   &.edit-save {
-    color: var(--color-icon);
     :hover {
-      color: black;
+      color: var(--color-edit-hover);
     }
+  }
+  &.hoverable {
+    .hover {
+      display: none;
+    }
+    .default {
+      display: block;
+    }
+    &:hover {
+      .hover {
+        display: block;
+      }
+      .default {
+        display: none;
+      }
+    }
+  }
+  &:hover {
+    cursor: pointer;
   }
 }
 
@@ -412,27 +430,9 @@ button:focus-visible {
 }
 
 .icon {
+  pointer-events: all;
   height: 100%;
   width: 100%;
-  pointer-events: all;
-}
-
-.hoverable {
-  .filled {
-    display: none;
-  }
-  .regular {
-    display: block;
-  }
-  &:hover {
-    cursor: pointer;
-    .filled {
-      display: block;
-    }
-    .regular {
-      display: none;
-    }
-  }
 }
 
 .buttons {

--- a/client/src/Citation.tsx
+++ b/client/src/Citation.tsx
@@ -1,12 +1,17 @@
 import { Review } from "./Types";
 import {
   CircleRegular,
+  CheckmarkCircleRegular,
   CheckmarkCircleFilled,
   DismissCircleFilled,
+  DismissCircleRegular,
   EditFilled,
+  EditRegular,
   CheckmarkRegular,
   DismissRegular,
+  FluentIcon,
 } from "@fluentui/react-icons";
+
 import { useDispatchHandler } from "./Hooks";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatchAppState } from "./State";
@@ -77,6 +82,13 @@ export const CitationUX = ({
     }
   }, [editing, excerpt]);
 
+  const hoverableIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => (
+    <>
+      <FilledIcon className="icon filled" />
+      <RegularIcon className="icon regular" />
+    </>
+  );
+
   return (
     <div
       className={`citation ${selected ? "selected" : "unselected"}`}
@@ -97,11 +109,11 @@ export const CitationUX = ({
               onChange={onChangeExcerpt}
               onClick={(e) => e.stopPropagation()}
             />
-            <div className="editor-cancel" onClick={cancelEditExcerpt}>
-              <DismissRegular className="edit-icon" />
+            <div className="citation-icon edit-cancel" onClick={cancelEditExcerpt}>
+              <DismissRegular className="icon" />
             </div>
-            <div onClick={updateExcerpt}>
-              <CheckmarkRegular className="edit-icon" />
+            <div className="citation-icon edit-save" onClick={updateExcerpt}>
+              <CheckmarkRegular className="icon" />
             </div>
           </>
         ) : (
@@ -111,31 +123,34 @@ export const CitationUX = ({
             </div>
             {review === Review.Unreviewed ? (
               <>
-                <div key="approve">
-                  <CheckmarkCircleFilled
-                    className="icon citation-icon approved off"
-                    onClick={dispatchUnlessAsyncing({
-                      type: "reviewCitation",
-                      review: Review.Approved,
-                      citationIndex,
-                    })}
-                  />
+                <div
+                  key="approve"
+                  className="citation-icon approved off hoverable"
+                  onClick={dispatchUnlessAsyncing({
+                    type: "reviewCitation",
+                    review: Review.Approved,
+                    citationIndex,
+                  })}
+                >
+                  {hoverableIcon(CheckmarkCircleFilled, CheckmarkCircleRegular)}
                 </div>
-                <div key="reject">
-                  <DismissCircleFilled
-                    className="icon citation-icon rejected off"
-                    onClick={dispatchUnlessAsyncing({
-                      type: "reviewCitation",
-                      review: Review.Rejected,
-                      citationIndex,
-                    })}
-                  />
+                <div
+                  key="reject"
+                  className="citation-icon rejected off hoverable"
+                  onClick={dispatchUnlessAsyncing({
+                    type: "reviewCitation",
+                    review: Review.Rejected,
+                    citationIndex,
+                  })}
+                >
+                  {hoverableIcon(DismissCircleFilled, DismissCircleRegular)}
                 </div>
-                <div key="edit">
-                  <EditFilled
-                    className="icon citation-icon edit"
-                    onClick={startEditExcerpt}
-                  />
+                <div
+                  key="edit"
+                  className="citation-icon edit-start hoverable"
+                  onClick={startEditExcerpt}
+                >
+                  {hoverableIcon(EditFilled, EditRegular)}
                 </div>
               </>
             ) : review === Review.Approved ? (

--- a/client/src/Citation.tsx
+++ b/client/src/Citation.tsx
@@ -13,7 +13,7 @@ import {
 } from "@fluentui/react-icons";
 
 import { useDispatchHandler } from "./Hooks";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatchAppState } from "./State";
 
 interface Props {
@@ -61,10 +61,10 @@ export const CitationUX = ({
 
   const updateExcerpt = useCallback(
     (e: React.MouseEvent) => {
-      dispatch({ type: "updateExcerpt", excerpt: editExcerpt, citationIndex });
+      dispatch({ type: "updateExcerpt", excerpt: editExcerpt });
       e.stopPropagation();
     },
-    [dispatch, editExcerpt, citationIndex]
+    [dispatch, editExcerpt]
   );
 
   const onChangeExcerpt = useCallback(
@@ -72,7 +72,7 @@ export const CitationUX = ({
       setEditExcerpt(e.target.value);
       e.stopPropagation();
     },
-    [setEditExcerpt]
+    []
   );
 
   useEffect(() => {
@@ -80,13 +80,105 @@ export const CitationUX = ({
       editExcerptRef.current.focus();
       editExcerptRef.current.select();
     }
-  }, [editing, excerpt]);
+  }, [editing]);
 
-  const hoverableIcon = (FilledIcon: FluentIcon, RegularIcon: FluentIcon) => (
-    <>
-      <FilledIcon className="icon filled" />
-      <RegularIcon className="icon regular" />
-    </>
+  const hoverableIcon = useCallback(
+    (DefaultIcon: FluentIcon, HoverIcon: FluentIcon) => (
+      <>
+        <DefaultIcon className="icon default" />
+        <HoverIcon className="icon hover" />
+      </>
+    ),
+    []
+  );
+
+  const Approve = useMemo(
+    () => () =>
+      (
+        <div
+          key="approve"
+          className="citation-icon approved off hoverable"
+          onClick={dispatchUnlessAsyncing({
+            type: "reviewCitation",
+            review: Review.Approved,
+            citationIndex,
+          })}
+        >
+          {hoverableIcon(CheckmarkCircleRegular, CheckmarkCircleFilled)}
+        </div>
+      ),
+    [citationIndex, dispatchUnlessAsyncing, hoverableIcon]
+  );
+
+  const Reject = useMemo(
+    () => () =>
+      (
+        <div
+          key="reject"
+          className="citation-icon rejected off hoverable"
+          onClick={dispatchUnlessAsyncing({
+            type: "reviewCitation",
+            review: Review.Rejected,
+            citationIndex,
+          })}
+        >
+          {hoverableIcon(DismissCircleRegular, DismissCircleFilled)}
+        </div>
+      ),
+    [citationIndex, dispatchUnlessAsyncing, hoverableIcon]
+  );
+
+  const Edit = useMemo(() => () => (
+    <div
+  key="edit"
+  className="citation-icon edit-start hoverable"
+  onClick={startEditExcerpt}
+>
+  {hoverableIcon(EditRegular, EditFilled)}
+    </div>
+  ), [startEditExcerpt, hoverableIcon]);
+
+  const Unreviewed = useMemo(
+    () => () => (
+      <div className="icon citation-icon unreviewed">
+        <CircleRegular className="icon" />
+      </div>
+    ),
+    []
+  );
+
+  const Approved = useMemo(
+    () => () =>
+      (
+        <div
+          className="citation-icon approved on hoverable"
+          onClick={dispatchUnlessAsyncing({
+            type: "reviewCitation",
+            review: Review.Unreviewed,
+            citationIndex,
+          })}
+        >
+          {hoverableIcon(CheckmarkCircleFilled, CheckmarkCircleRegular)}
+        </div>
+      ),
+    [citationIndex, dispatchUnlessAsyncing, hoverableIcon]
+  );
+
+  const Rejected = useMemo(
+    () => () =>
+      (
+        <div
+          className="citation-icon rejected on hoverable"
+          onClick={dispatchUnlessAsyncing({
+            type: "reviewCitation",
+            review: Review.Unreviewed,
+            citationIndex,
+          })}
+        >
+          {hoverableIcon(DismissCircleFilled, DismissCircleRegular)}
+        </div>
+      ),
+    [citationIndex, dispatchUnlessAsyncing, hoverableIcon]
   );
 
   return (
@@ -109,7 +201,10 @@ export const CitationUX = ({
               onChange={onChangeExcerpt}
               onClick={(e) => e.stopPropagation()}
             />
-            <div className="citation-icon edit-cancel" onClick={cancelEditExcerpt}>
+            <div
+              className="citation-icon edit-cancel"
+              onClick={cancelEditExcerpt}
+            >
               <DismissRegular className="icon" />
             </div>
             <div className="citation-icon edit-save" onClick={updateExcerpt}>
@@ -123,86 +218,26 @@ export const CitationUX = ({
             </div>
             {review === Review.Unreviewed ? (
               <>
-                <div
-                  key="approve"
-                  className="citation-icon approved off hoverable"
-                  onClick={dispatchUnlessAsyncing({
-                    type: "reviewCitation",
-                    review: Review.Approved,
-                    citationIndex,
-                  })}
-                >
-                  {hoverableIcon(CheckmarkCircleFilled, CheckmarkCircleRegular)}
-                </div>
-                <div
-                  key="reject"
-                  className="citation-icon rejected off hoverable"
-                  onClick={dispatchUnlessAsyncing({
-                    type: "reviewCitation",
-                    review: Review.Rejected,
-                    citationIndex,
-                  })}
-                >
-                  {hoverableIcon(DismissCircleFilled, DismissCircleRegular)}
-                </div>
-                <div
-                  key="edit"
-                  className="citation-icon edit-start hoverable"
-                  onClick={startEditExcerpt}
-                >
-                  {hoverableIcon(EditFilled, EditRegular)}
-                </div>
+                <Approve />
+                <Reject />
+                <Edit />
               </>
             ) : review === Review.Approved ? (
-              <div>
-                <CheckmarkCircleFilled
-                  className="icon citation-icon approved on"
-                  onClick={dispatchUnlessAsyncing({
-                    type: "reviewCitation",
-                    review: Review.Unreviewed,
-                    citationIndex,
-                  })}
-                />
-              </div>
+              <Approved />
             ) : (
-              <div>
-                <DismissCircleFilled
-                  className="icon citation-icon rejected on"
-                  onClick={dispatchUnlessAsyncing({
-                    type: "reviewCitation",
-                    review: Review.Unreviewed,
-                    citationIndex,
-                  })}
-                />
-              </div>
+              <Rejected />
             )}
           </>
         )
       ) : (
         <>
-          <div>
-            {review === Review.Unreviewed ? (
-              <CircleRegular className="icon citation-icon unreviewed" />
-            ) : review === Review.Approved ? (
-              <CheckmarkCircleFilled
-                className="icon citation-icon approved on"
-                onClick={dispatchUnlessAsyncing({
-                  type: "reviewCitation",
-                  review: Review.Unreviewed,
-                  citationIndex,
-                })}
-              />
-            ) : (
-              <DismissCircleFilled
-                className="icon citation-icon rejected on"
-                onClick={dispatchUnlessAsyncing({
-                  type: "reviewCitation",
-                  review: Review.Unreviewed,
-                  citationIndex,
-                })}
-              />
-            )}
-          </div>
+          {review === Review.Unreviewed ? (
+            <Unreviewed />
+          ) : review === Review.Approved ? (
+            <Approved />
+          ) : (
+            <Rejected />
+          )}
           <div className="citation-excerpt">{excerpt}</div>
         </>
       )}

--- a/client/src/State.ts
+++ b/client/src/State.ts
@@ -410,10 +410,12 @@ const stateAtom = atom<State, [Action], void>(
 
               case "updateExcerpt": {
                 console.assert(!isAsyncing);
+                console.assert(ux.selectedCitation !== undefined);
                 console.assert(ux.selectedCitation?.editing !== undefined);
                 ux.selectedCitation!.editing = undefined;
 
-                const { excerpt, citationIndex } = action;
+                const { excerpt } = action;
+                const { citationIndex } = ux.selectedCitation!;
 
                 const citation =
                   questions[ux.questionIndex].citations[citationIndex];
@@ -421,7 +423,6 @@ const stateAtom = atom<State, [Action], void>(
                 if (citation.excerpt === excerpt) return;
 
                 citation.excerpt = excerpt;
-
 
                 setAsync({
                   event: {

--- a/client/src/Types.ts
+++ b/client/src/Types.ts
@@ -59,7 +59,6 @@ export type Action =
     }
   | {
       type: "updateExcerpt";
-      citationIndex: number;
       excerpt: string;
     }
   | {


### PR DESCRIPTION
With this change citation icons (approve, reject, edit) for unreviewed citations now default to the lighter "Regular" form of the icon, showing the Filled version only on hover. Reviewed citations continue to show Filled icons, but hovering now shows the Regular version. This makes for a lighter, more attractive UX, and more of a visual contrast between default and hover states.