### PR TITLE
Scroll #sidebar and #viewer independently

### DIFF
--- a/client/src/AnswerPanel.tsx
+++ b/client/src/AnswerPanel.tsx
@@ -85,7 +85,7 @@ export const AnswerPanel = () => {
   );
 
   return (
-    <div>
+    <>
       <Breadcrumbs
         breadcrumbs={[["Home", "/"], ["Form", `/${formId}`], ["Question"]]}
       />
@@ -130,6 +130,6 @@ export const AnswerPanel = () => {
       ) : (
         <ReviewPanel />
       )}
-    </div>
+    </>
   );
 };

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -31,6 +31,8 @@
   --rounding-height: 3px;
   --icon-size: 30px;
 
+  --sidebar-width: 400px;
+
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -48,12 +50,13 @@ h1 {
 
 #review-panel {
   position: relative;
-  display: grid;
-  grid-template-columns: 400px auto;
+  flex-shrink: 1;
+  min-height: 0;
+  display: flex;
   align-items: start;
   background-color: var(--color-base);
   color: var(--color-text);
-  overflow: scroll;
+  overflow-x: auto;
 }
 
 #review-container {
@@ -103,10 +106,14 @@ h1 {
 }
 
 #sidebar {
+  width: var(--sidebar-width);
+  max-height: 100%;
+  flex-shrink: 0;
   display: grid;
   grid-template-columns: 10px 10px 10px 10px auto 10px;
+  grid-template-rows: max-content auto;
   background-color: var(--color-base);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 #citations-label {
@@ -400,9 +407,16 @@ h1 {
   }
 }
 
+#viewer {
+  flex-grow: 1;
+  flex-shrink: 0;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 #viewer-viewport {
   position: relative;
-  overflow: scroll;
 }
 
 .viewer-citations {
@@ -499,6 +513,8 @@ h1 {
 #app {
   height: 100vh;
   background-color: var(--color-base);
+  display: flex;
+  flex-direction: column;
 }
 
 #question-container {


### PR DESCRIPTION
I've done my best to preserve the general behavior and appearance of things, with the exception of scrolling the two panels separately and removing some excess always-shown scrollbars (making them `auto` instead). I've tried resizing the browser a fair bit and it seems like it maintains behavior that makes sense to me, but if there's anything you feel can be improved please let me know!