### PR TITLE
Enable selection mark highlights

### DIFF
--- a/client/src/Utility.ts
+++ b/client/src/Utility.ts
@@ -276,7 +276,17 @@ const findBoundingRegions = (
       //   });
       //   if (textIndex == text.length) return boundingRegions;
       // }
-      if (match(word.content, text[textIndex])) {
+
+      // Selection marks do not come back in the page.words and therefore do not have the bounds. 
+      // selction marks are available in the paragraphs and lines but we don't currently use those fields.
+      // When we encounter a selection mark from the `text` array, we skip it and continue to the next word from the `text` array.
+      let currWord = text[textIndex];
+      while (currWord == ":unselected:" || currWord == ":selected:"){
+        textIndex++;
+        currWord = text[textIndex];
+        if (textIndex == text.length) return boundingRegions;
+      }  
+      if (match(word.content, currWord)) {
         textIndex++;
         boundingRegions.push({
           pageNumber: pageIndex + 1,


### PR DESCRIPTION
Doc Intelligence results for selection marks do not come back in the `pages.words` section of the response. The content field does contain the selection mark keywords, which means an excerpt that contains the selection mark keywords are unable to find an exact match in the UI. 

This PR will skip those keywords and move on the next word in the excerpt. This may not be the best way to solve this problem, so if we foresee skipping these keywords as a potential issue then we should come up with a design that will enable selection marks to be highlighted. 

This has been tested and will display the citation correctly when the excerpt contains those keywords. For more info on the selection marks see https://learn.microsoft.com/en-us/python/api/azure-ai-formrecognizer/azure.ai.formrecognizer.documentselectionmark?view=azure-python#azure-ai-formrecognizer-documentselectionmark-state


Ex:
AnalyzeResult
```json
"content": "This is a check mark example :selected: Yes ✘ :unslected: No",
"pages": [
    {
        "page_number": 1,
        "words": [
            {
                "content": "this"
                "polygon": [...]
            },
            {
                "content": "is"
                "polygon": [...]
            },
            {
                "content": "a"
                "polygon": [...]
            },
            {
                "content": "check"
                "polygon": [...]
            },
            {
                "content": "mark"
                "polygon": [...]
            },
            {
                "content": "example"
                "polygon": [...]
            },
            // :selected: is not available here 
            {
                "content": "Yes"
                "polygon": [...]
            },
            {
                "content": "✘"
                "polygon": [...]
            },
            // :unselected: is not available here 
            {
                "content": "No"
                "polygon": [...]
            },
        ]
    }
]
```