### PR TITLE
Update citation excerpt length for sql db

### DIFF
--- a/reference-azure-backend/functions/src/entity/Citation.ts
+++ b/reference-azure-backend/functions/src/entity/Citation.ts
@@ -35,7 +35,7 @@ export class Citation {
     @RelationId((citations: Citation) => citations.document)
     documentId: number;
 
-    @Column({ type: 'nvarchar', length: 255 })
+    @Column({ type: 'nvarchar', length: 'MAX' })
     excerpt!: string;
 
     @Column({ type: 'simple-json', nullable: true })


### PR DESCRIPTION
We hit issues with the length being too short for citations, so this updates the length to MAX. 