### PR TITLE
Bug fix for non-adjacent bounding regions

### DIFF
--- a/client/src/Utility.ts
+++ b/client/src/Utility.ts
@@ -213,9 +213,21 @@ export const condenseRegions = (boundingRegions: Bounds[]) => {
           boundingRegions[index].polygon
         );
       } else {
-        // New column or similar
-        condensedRegions.push(boundingRegions[index]);
-        last++;
+        // create new polygon to bridge non-adjacent polygons
+        const intermediaryPolygon = polygonize(
+          [condensedRegions[last].polygon[2], boundingRegions[index].polygon[0]],
+          [
+            Math.min(condensedRegions[last].polygon[3], boundingRegions[index].polygon[1]), 
+            Math.max(condensedRegions[last].polygon[5], boundingRegions[index].polygon[7])
+          ]
+        );
+
+        // combine polygons
+        condensedRegions[last].polygon = combinePolygons([
+          condensedRegions[last].polygon, 
+          intermediaryPolygon, 
+          boundingRegions[index].polygon
+        ]);
       }
     } else {
       // new page


### PR DESCRIPTION
@billba @lee0c Please let me know if this looks alright - not sure if there was a different intention for "condensedRegions" as an array rather than a single object.

Non-adjacent bounding regions are currently returned as an array, and only the top region is highlighted.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/e38bcdf2-e72a-442b-ac2f-a72db1689a4c" />

This fix adds a new polygon to bridge the two non-adjacent polygons before combining all three polygons into a single bounding region.

<img width="958" alt="image" src="https://github.com/user-attachments/assets/90312032-df12-4468-9385-feb98f6833aa" />
