### PR TITLE
Manual citation button update

### DIFF
--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -29,7 +29,7 @@ const sortIndex = sortBy(
 
 export function Sidebar() {
   const [state, dispatch] = useAppState();
-  const { questions, ux, docs } = state as LoadedState;
+  const { questions, ux, docs, isTextLayerEmpty } = state as LoadedState;
   const { questionIndex, selectedCitation, documentId } = ux;
   const question = questions[questionIndex];
   const { citations } = question;
@@ -214,16 +214,17 @@ export function Sidebar() {
           )}
           <div id="answer">
             <div className="answer-section">
-              You can manually add additional citations by navigating the
-              documents, selecting relevant text, and
-              {isAsyncing || ux.range == undefined ? (
-                " clicking here"
+              To manually add a citation, highlight the relevant text and click
+              the button that pops up below. Some documents may contain text that 
+              is not selectable.
+              {isAsyncing || ux.range == undefined || isTextLayerEmpty ? (
+                " "
               ) : (
                 <>
                   &nbsp;
-                  <span className="action" onClick={addSelection}>
-                    clicking here
-                  </span>
+                  <button className="action" onClick={addSelection}>
+                    add new citation
+                  </button>
                 </>
               )}
             </div>

--- a/client/src/State.ts
+++ b/client/src/State.ts
@@ -475,6 +475,12 @@ const stateAtom = atom<State, [Action], void>(
                     break;
                   }
 
+                  case "emptyTextLayer": { 
+                    const {isTextLayerEmpty} = action;
+                    state.isTextLayerEmpty = isTextLayerEmpty;
+                    break;
+                  }
+
                   case "addSelection": {
                     console.assert(!isAsyncing);
                     console.assert(ux.range !== undefined);

--- a/client/src/Types.ts
+++ b/client/src/Types.ts
@@ -62,6 +62,10 @@ export type Action =
       height: number;
     }
   | {
+      type: "emptyTextLayer";
+      isTextLayerEmpty: boolean;
+    }
+  | {
       type: "addSelection";
     }
   | {
@@ -259,6 +263,7 @@ export type LoadedState = {
   asyncState: AsyncState;
   viewer: ViewerState;
   docs: FormDocument[];
+  isTextLayerEmpty?: boolean;
 } & Form;
 
 export type State =

--- a/client/src/Viewer.tsx
+++ b/client/src/Viewer.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { Document, Page } from "react-pdf";
+import { TextContent } from "pdfjs-dist/types/src/display/api";
+
 import {
   CheckmarkCircleFilled,
   CheckmarkCircleRegular,
@@ -70,6 +72,14 @@ export function Viewer() {
 
   const onDocumentLoadSuccess = useCallback(() => {}, []);
 
+  const onTextLayerRender = useCallback((text: TextContent) => {
+    dispatch({  
+      type: "emptyTextLayer",
+      isTextLayerEmpty: (text.items.length == 0), 
+    });
+  }, [dispatch]
+);
+
   const updateViewerSize = useCallback(
     ({ height, width }: PageCallback) => {
       dispatch({
@@ -127,6 +137,7 @@ export function Viewer() {
                   onRenderSuccess={updateViewerSize}
                   className="viewer-page"
                   renderAnnotationLayer={false}
+                  onGetTextSuccess={onTextLayerRender}
             />
           </Document>
           <ViewerCitations />


### PR DESCRIPTION
Updates the manual citation button to only pop up when you highlight text and also gives a warning that some pages may have unselectable text

![image](https://github.com/user-attachments/assets/3d6ccac7-791a-4a42-ae30-88d91d41454f)

![image](https://github.com/user-attachments/assets/c9a5edca-9c7e-41dc-9863-5506f6f73856)
