### PR TITLE
Update all table references from plural to singular

### DIFF
--- a/reference-azure-backend/create-psql.sql
+++ b/reference-azure-backend/create-psql.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS templates, questions, forms, documents, citations, events;
+DROP TABLE IF EXISTS template, question, form, document, citation, event;
 
-CREATE TABLE templates (
+CREATE TABLE template (
   templateId SERIAL PRIMARY KEY,
   templateName TEXT NOT NULL,
   creator TEXT NOT NULL,
@@ -8,9 +8,9 @@ CREATE TABLE templates (
   modifiedAt TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE questions (
+CREATE TABLE question (
   questionId SERIAL PRIMARY KEY,
-  templateId INTEGER REFERENCES templates(templateId),
+  templateId INTEGER REFERENCES template(templateId),
   prefix TEXT,
   text TEXT NOT NULL,
   creator TEXT NOT NULL,
@@ -18,18 +18,18 @@ CREATE TABLE questions (
   modifiedAt TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE forms (
+CREATE TABLE form (
   formId SERIAL PRIMARY KEY,
-  templateId INTEGER REFERENCES templates(templateId),
+  templateId INTEGER REFERENCES template(templateId),
   formName TEXT NOT NULL,
   creator TEXT NOT NULL,
   createdAt TIMESTAMP NOT NULL DEFAULT NOW(),
   modifiedAt TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE documents (
+CREATE TABLE document (
   documentId SERIAL PRIMARY KEY,
-  formId INTEGER REFERENCES forms(formId),
+  formId INTEGER REFERENCES form(formId),
   name TEXT,
   pdfUrl TEXT NOT NULL,
   diUrl TEXT,
@@ -38,11 +38,11 @@ CREATE TABLE documents (
   modifiedAt TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE citations (
+CREATE TABLE citation (
   citationId TEXT PRIMARY KEY,
-  formId INTEGER REFERENCES forms(formId),
-  questionId INTEGER REFERENCES questions(questionId),
-  documentId INTEGER REFERENCES documents(documentId),
+  formId INTEGER REFERENCES form(formId),
+  questionId INTEGER REFERENCES question(questionId),
+  documentId INTEGER REFERENCES document(documentId),
   excerpt TEXT NOT NULL,
   bounds JSONB,
   review INTEGER NOT NULL DEFAULT 0,
@@ -51,17 +51,17 @@ CREATE TABLE citations (
   modifiedAt TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE events (
+CREATE TABLE event (
   event_id SERIAL PRIMARY KEY,
   body JSONB NOT NULL,
   createdAt TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-INSERT INTO templates (templateName, creator)
+INSERT INTO template (templateName, creator)
 VALUES
   ('Microsoft Fiscal', 'system');
 
-INSERT INTO questions (templateId, prefix, text, creator)
+INSERT INTO question (templateId, prefix, text, creator)
 VALUES
   (1, '1', 'What was the company''s revenue for the third quarter of Fiscal Year 2024?', 'system'),
   (1, '2', 'What are the earnings per share (EPS) for this quarter?', 'system'),
@@ -70,16 +70,16 @@ VALUES
   (1, '5', 'Are there any ongoing legal proceedings?', 'system'),
   (1, '6', 'What is an excerpt that spans two pages?', 'system');
 
-INSERT INTO forms (templateId, formName, creator)
+INSERT INTO form (templateId, formName, creator)
 VALUES
   (1, 'FY24Q3', 'system');
 
-INSERT INTO documents (formId, name, pdfUrl, diUrl, creator) 
+INSERT INTO document (formId, name, pdfUrl, diUrl, creator) 
 VALUES 
   (1, 'PressReleaseFY24Q3', 'https://excitation.blob.core.windows.net/documents/PressReleaseFY24Q3.pdf', 'https://excitation.blob.core.windows.net/documents/PressReleaseFY24Q3.pdf.json', 'system'),
   (1, 'Microsoft 10Q FY24Q3 1', 'https://excitation.blob.core.windows.net/documents/Microsoft 10Q FY24Q3 1.pdf', 'https://excitation.blob.core.windows.net/documents/Microsoft 10Q FY24Q3 1.pdf.json', 'system');
 
-INSERT INTO citations (citationId, formId, questionId, documentId, excerpt, creator)
+INSERT INTO citation (citationId, formId, questionId, documentId, excerpt, creator)
 VALUES
   ('1-system-1732038032110', 1, 1, 1, 'Revenue was $61.9 billion and increased 17%', 'system'),
   ('1-system-1732038042614', 1, 1, 2, '61,858', 'system'),

--- a/reference-azure-backend/create-sql.sql
+++ b/reference-azure-backend/create-sql.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS templates, questions, forms, documents, citations, events;
+DROP TABLE IF EXISTS template, question, form, document, citation, event;
 
-CREATE TABLE dbo.templates (
+CREATE TABLE dbo.template (
   templateId INT IDENTITY(1,1) PRIMARY KEY,
   templateName TEXT NOT NULL,
   creator TEXT NOT NULL,
@@ -8,9 +8,9 @@ CREATE TABLE dbo.templates (
   modifiedAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-CREATE TABLE dbo.questions (
+CREATE TABLE dbo.question (
   questionId INT IDENTITY(1,1) PRIMARY KEY,
-  templateId INTEGER REFERENCES templates(templateId),
+  templateId INTEGER REFERENCES template(templateId),
   prefix TEXT,
   text TEXT NOT NULL,
   creator TEXT NOT NULL,
@@ -18,18 +18,18 @@ CREATE TABLE dbo.questions (
   modifiedAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-CREATE TABLE dbo.forms (
+CREATE TABLE dbo.form (
   formId INT IDENTITY(1,1) PRIMARY KEY,
-  templateId INTEGER REFERENCES templates(templateId),
+  templateId INTEGER REFERENCES template(templateId),
   formName TEXT NOT NULL,
   creator TEXT NOT NULL,
   createdAt DATETIME NOT NULL DEFAULT GETDATE(),
   modifiedAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-CREATE TABLE dbo.documents (
+CREATE TABLE dbo.document (
   documentId INT IDENTITY(1,1) PRIMARY KEY,
-  formId INTEGER REFERENCES forms(formId),
+  formId INTEGER REFERENCES form(formId),
   name TEXT,
   pdfUrl TEXT NOT NULL,
   diUrl TEXT,
@@ -38,21 +38,21 @@ CREATE TABLE dbo.documents (
   modifiedAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-CREATE TABLE dbo.answers (
+CREATE TABLE dbo.answer (
   answerId VARCHAR(256) PRIMARY KEY,
-  formId INTEGER REFERENCES forms(formId),
-  questionId INTEGER REFERENCES questions(questionId),
+  formId INTEGER REFERENCES form(formId),
+  questionId INTEGER REFERENCES question(questionId),
   answer TEXT NOT NULL,
   creator TEXT NOT NULL,
   createdAt DATETIME NOT NULL DEFAULT GETDATE(),
   modifiedAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-CREATE TABLE dbo.citations (
+CREATE TABLE dbo.citation (
   citationId VARCHAR(256) PRIMARY KEY,
-  formId INTEGER REFERENCES forms(formId),
-  questionId INTEGER REFERENCES questions(questionId),
-  documentId INTEGER REFERENCES documents(documentId),
+  formId INTEGER REFERENCES form(formId),
+  questionId INTEGER REFERENCES question(questionId),
+  documentId INTEGER REFERENCES document(documentId),
   excerpt TEXT NOT NULL,
   bounds JSON,
   review INTEGER NOT NULL DEFAULT 0,
@@ -61,17 +61,17 @@ CREATE TABLE dbo.citations (
   modifiedAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-CREATE TABLE dbo.events (
+CREATE TABLE dbo.event (
   event_id INT IDENTITY(1,1) PRIMARY KEY,
   body JSON NOT NULL,
   createdAt DATETIME NOT NULL DEFAULT GETDATE()
 );
 
-INSERT INTO dbo.templates (templateName, creator)
+INSERT INTO dbo.template (templateName, creator)
 VALUES
   ('Microsoft Fiscal', 'system');
 
-INSERT INTO dbo.questions (templateId, prefix, text, creator)
+INSERT INTO dbo.question (templateId, prefix, text, creator)
 VALUES
   (1, '1', 'What was the company''s revenue for the third quarter of Fiscal Year 2024?', 'system'),
   (1, '2', 'What are the earnings per share (EPS) for this quarter?', 'system'),
@@ -80,16 +80,16 @@ VALUES
   (1, '5', 'Are there any ongoing legal proceedings?', 'system'),
   (1, '6', 'What is an excerpt that spans two pages?', 'system');
 
-INSERT INTO dbo.forms (templateId, formName, creator)
+INSERT INTO dbo.form (templateId, formName, creator)
 VALUES
   (1, 'FY24Q3', 'system');
 
-INSERT INTO dbo.documents (formId, name, pdfUrl, diUrl, creator) 
+INSERT INTO dbo.document (formId, name, pdfUrl, diUrl, creator) 
 VALUES 
   (1, 'PressReleaseFY24Q3', 'https://excitation.blob.core.windows.net/documents/PressReleaseFY24Q3.pdf', 'https://excitation.blob.core.windows.net/documents/PressReleaseFY24Q3.pdf.json', 'system'),
   (1, 'Microsoft 10Q FY24Q3 1', 'https://excitation.blob.core.windows.net/documents/Microsoft 10Q FY24Q3 1.pdf', 'https://excitation.blob.core.windows.net/documents/Microsoft 10Q FY24Q3 1.pdf.json', 'system');
 
-INSERT INTO dbo.citations (citationId, formId, questionId, documentId, excerpt, creator)
+INSERT INTO dbo.citation (citationId, formId, questionId, documentId, excerpt, creator)
 VALUES
   ('1-system-1732038032110', 1, 1, 1, 'Revenue was $61.9 billion and increased 17%', 'system'),
   ('1-system-1732038042614', 1, 1, 2, '61,858', 'system'),

--- a/reference-azure-backend/functions/src/functions-psql/post.ts
+++ b/reference-azure-backend/functions/src/functions-psql/post.ts
@@ -2,7 +2,7 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/fu
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
 import postgres from 'postgres';
-import { citations, events } from '../schema'
+import { citationSchema, eventSchema } from '../schema'
 import { Bounds, Review, Event } from '../types'
 
 export const createCitationId = (formId: number, creator: string) => {
@@ -13,11 +13,11 @@ export const createCitationId = (formId: number, creator: string) => {
 // db operations
 // ============================================================================
 
-// Inserts into db citations table
+// Inserts into db citation table
 async function insertCitation(db: PostgresJsDatabase, formId: number, questionId: number, documentId: number, excerpt: string, bounds: Bounds[], review: Review, creator: string) {
   const citationId = createCitationId(formId, creator);
   /* @ts-ignore */
-  return await db.insert(citations).values({
+  return await db.insert(citationSchema).values({
     citationId,
     formId,
     questionId,
@@ -29,59 +29,59 @@ async function insertCitation(db: PostgresJsDatabase, formId: number, questionId
   }).returning();
 }
 
-// Updates db citations table
+// Updates db citation table
 async function updateCitationBounds(db: PostgresJsDatabase, citationId: string, bounds: Bounds[]) {
-  return db.update(citations).set({
+  return db.update(citationSchema).set({
     /* @ts-ignore */
     bounds,
-  }).where(eq(citations.citationId, citationId)).returning({
-    citationId: citations.citationId,
-    excerpt: citations.excerpt,
-    bounds: citations.bounds
+  }).where(eq(citationSchema.citationId, citationId)).returning({
+    citationId: citationSchema.citationId,
+    excerpt: citationSchema.excerpt,
+    bounds: citationSchema.bounds
   });
 }
 
 async function updateCitationReview(db: PostgresJsDatabase, citationId: string, review: Review) {
-  return db.update(citations).set({
+  return db.update(citationSchema).set({
     /* @ts-ignore */
     review
-  }).where(eq(citations.citationId, citationId)).returning({
-    citationId: citations.citationId,
-    excerpt: citations.excerpt,
-    review: citations.review
+  }).where(eq(citationSchema.citationId, citationId)).returning({
+    citationId: citationSchema.citationId,
+    excerpt: citationSchema.excerpt,
+    review: citationSchema.review
   });
 }
 
-// Inserts into db events table
+// Inserts into db event table
 async function insertAddEvent(db: PostgresJsDatabase, event: Event) {
   /* @ts-ignore */
-  return db.insert(events).values({
+  return db.insert(eventSchema).values({
     body: event
   }).returning({
-    body: events.body,
-    createdAt: events.createdAt
+    body: eventSchema.body,
+    createdAt: citationSchema.createdAt
   });
 }
 
-// Inserts into db events table
+// Inserts into db event table
 async function insertUpdateReviewEvent(db: PostgresJsDatabase, event: Event) {
   /* @ts-ignore */
-  return db.insert(events).values({
+  return db.insert(eventSchema).values({
     body: event
   }).returning({
-    body: events.body,
-    createdAt: events.createdAt
+    body: eventSchema.body,
+    createdAt: eventSchema.createdAt
   });
 }
 
-// Inserts into db events table
+// Inserts into db event table
 async function insertUpdateBoundsEvent(db: PostgresJsDatabase, event: Event) {
   /* @ts-ignore */
-  return db.insert(events).values({
+  return db.insert(eventSchema).values({
     body: event
   }).returning({
-    body: events.body,
-    createdAt: events.createdAt
+    body: eventSchema.body,
+    createdAt: eventSchema.createdAt
   });
 }
 

--- a/reference-azure-backend/functions/src/functions/get.ts
+++ b/reference-azure-backend/functions/src/functions/get.ts
@@ -12,11 +12,11 @@ import { Answer } from "../entity/Answer";
 // db operations
 // ============================================================================
 async function getFormMetadata(db: DataSource, formId: number) {
-  const formsRepository = db.getRepository(Form);
-  const templatesRepository = db.getRepository(Template);
+  const formRepository = db.getRepository(Form);
+  const templateRepository = db.getRepository(Template);
 
   // get template id
-  const form = await formsRepository.findOne({
+  const form = await formRepository.findOne({
     where: { formId: formId },
     select: ['formName', 'templateId']
   });
@@ -24,7 +24,7 @@ async function getFormMetadata(db: DataSource, formId: number) {
   const templateId = form.templateId;
 
   // get template info
-  const template = await templatesRepository.findOne({
+  const template = await templateRepository.findOne({
     where: { templateId: templateId },
     select: ['templateName']
   });
@@ -33,24 +33,24 @@ async function getFormMetadata(db: DataSource, formId: number) {
 }
 
 export async function getAnswer(db: DataSource, formId: number, questionId: number) {
-  const answersRepository = db.getRepository(Answer);
-  return await answersRepository.findOne({
+  const answerRepository = db.getRepository(Answer);
+  return await answerRepository.findOne({
     where: { formId: formId, questionId: questionId },
   });
 }
 
 async function getQuestionsWithCitations(db: DataSource, formId: number) {
-  const formsRepository = db.getRepository(Form);
-  const questionsRepository = db.getRepository(Question);
-  const citationsRepository = db.getRepository(Citation);
+  const formRepository = db.getRepository(Form);
+  const questionRepository = db.getRepository(Question);
+  const citationRepository = db.getRepository(Citation);
 
-  const form = await formsRepository.findOne({
+  const form = await formRepository.findOne({
     where: { formId: formId },
     select: ['templateId']
   });
   const templateId = form.templateId;
 
-  const qs = await questionsRepository.find({
+  const qs = await questionRepository.find({
     where: { templateId: templateId },
     order: { prefix: 'ASC', questionId: 'ASC' },
     select: ['questionId', 'prefix', 'text']
@@ -60,7 +60,7 @@ async function getQuestionsWithCitations(db: DataSource, formId: number) {
     prefix,
     text,
     questionId,
-    citations: await citationsRepository.find({
+    citations: await citationRepository.find({
       where: { formId: formId, questionId: questionId },
       order: { documentId: 'ASC', citationId: 'ASC' },
       select: ['citationId', 'documentId', 'excerpt', 'review', 'bounds']

--- a/reference-azure-backend/functions/src/functions/post.ts
+++ b/reference-azure-backend/functions/src/functions/post.ts
@@ -15,7 +15,7 @@ export const createCitationId = (formId: number, creator: string) => {
 // db operations
 // ============================================================================
 
-// Inserts into db citations table
+// Inserts into db citation table
 async function insertCitation(db: DataSource, formId: number, questionId: number, documentId: number, excerpt: string, bounds: Bounds[], review: Review, creator: string) {
   const citation = new Citation();
   const citationId = createCitationId(formId, creator);
@@ -31,28 +31,28 @@ async function insertCitation(db: DataSource, formId: number, questionId: number
   return await db.manager.save(citation);
 }
 
-// Updates db citations table
+// Updates db citation table
 async function updateCitationBounds(db: DataSource, citationId: string, bounds: Bounds[]) {
-  const citationsRepository = db.getRepository(Citation);
-  const citationToUpdate = await citationsRepository.findOne({
+  const citationRepository = db.getRepository(Citation);
+  const citationToUpdate = await citationRepository.findOne({
     where: { citationId: citationId },
     select: ['citationId', 'excerpt', 'bounds']
   });
   citationToUpdate.bounds = JSON.parse(JSON.stringify(bounds));
-  return await citationsRepository.save(citationToUpdate);
+  return await citationRepository.save(citationToUpdate);
 }
 
 async function updateCitationReview(db: DataSource, citationId: string, review: Review) {
-  const citationsRepository = db.getRepository(Citation);
-  const citationToUpdate = await citationsRepository.findOne({
+  const citationRepository = db.getRepository(Citation);
+  const citationToUpdate = await citationRepository.findOne({
     where: { citationId: citationId },
     select: ['citationId', 'excerpt', 'review']
   });
   citationToUpdate.review = review;
-  return await citationsRepository.save(citationToUpdate);
+  return await citationRepository.save(citationToUpdate);
 }
 
-// Inserts into db events table
+// Inserts into db event table
 async function insertAddEvent(db: DataSource, event: EventType) {
   const newEvent = new Event();
   newEvent.body = JSON.parse(JSON.stringify(event));
@@ -60,7 +60,7 @@ async function insertAddEvent(db: DataSource, event: EventType) {
   return await db.manager.save(newEvent);
 }
 
-// Inserts into db events table
+// Inserts into db event table
 async function insertUpdateReviewEvent(db: DataSource, event: EventType) {
   const newEvent = new Event();
   newEvent.body = JSON.parse(JSON.stringify(event));
@@ -68,7 +68,7 @@ async function insertUpdateReviewEvent(db: DataSource, event: EventType) {
   return await db.manager.save(newEvent);
 }
 
-// Inserts into db events table
+// Inserts into db event table
 async function insertUpdateBoundsEvent(db: DataSource, event: EventType) {
   const newEvent = new Event();
   newEvent.body = JSON.parse(JSON.stringify(event));
@@ -106,8 +106,8 @@ async function addReview(db: DataSource, context: InvocationContext, event: Even
 }
 
 async function updateAnswer(db: DataSource, answer: AnswerType) {
-    const answersRepository = db.getRepository(Answer);
-    answersRepository.save(answer);
+    const answerRepository = db.getRepository(Answer);
+    answerRepository.save(answer);
 }
 
 async function createAnswer(db: DataSource, formId: number, questionId: number, creator: string, answerText: string) {

--- a/reference-azure-backend/functions/src/schema.ts
+++ b/reference-azure-backend/functions/src/schema.ts
@@ -1,6 +1,6 @@
 import { integer, jsonb, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
 
-export const templates = pgTable('templates', {
+export const templateSchema = pgTable('template', {
   templateId: serial('templateId').primaryKey().notNull(),
   templateName: text('templateName').notNull(),
   creator: text('creator').notNull(),
@@ -8,9 +8,9 @@ export const templates = pgTable('templates', {
   modifiedAt: timestamp('modifiedAt').notNull().defaultNow()
 });
 
-export const questions = pgTable('questions', {
+export const questionSchema = pgTable('question', {
   questionId: serial('questionId').primaryKey().notNull(),
-  templateId: integer('templateId').references(() => templates.templateId),
+  templateId: integer('templateId').references(() => templateSchema.templateId),
   text: text('text').notNull(),
   prefix: text('prefix'),
   creator: text('creator').notNull(),
@@ -18,18 +18,18 @@ export const questions = pgTable('questions', {
   modifiedAt: timestamp('modifiedAt').notNull().defaultNow()
 });
 
-export const forms = pgTable('forms', {
+export const formSchema = pgTable('form', {
   formId: serial('formId').primaryKey().notNull(),
-  templateId: integer('templateId').references(() => templates.templateId),
+  templateId: integer('templateId').references(() => templateSchema.templateId),
   formName: text('formName').notNull(),
   creator: text('creator').notNull(),
   createdAt: timestamp('createdAt').notNull().defaultNow(),
   modifiedAt: timestamp('modifiedAt').notNull().defaultNow()
 });
 
-export const documents = pgTable('documents', {
+export const documentSchema = pgTable('document', {
   documentId: serial('documentId').primaryKey().notNull(),
-  formId: integer('formId').references(() => forms.formId),
+  formId: integer('formId').references(() => formSchema.formId),
   name: text('name'),
   pdfUrl: text('pdfUrl').notNull(),
   diUrl: text('diUrl'),
@@ -38,11 +38,11 @@ export const documents = pgTable('documents', {
   modifiedAt: timestamp('modifiedAt').notNull().defaultNow()
 });
 
-export const citations = pgTable('citations', {
+export const citationSchema = pgTable('citation', {
   citationId: text('citationId').primaryKey(),
-  formId: integer('formId').references(() => forms.formId),
-  questionId: integer('questionId').references(() => questions.questionId),
-  documentId: integer('documentId').references(() => documents.documentId),
+  formId: integer('formId').references(() => formSchema.formId),
+  questionId: integer('questionId').references(() => questionSchema.questionId),
+  documentId: integer('documentId').references(() => documentSchema.documentId),
   excerpt: text('excerpt').notNull(),
   bounds: jsonb('bounds'),
   review: integer('review').notNull().default(0),
@@ -51,7 +51,7 @@ export const citations = pgTable('citations', {
   modifiedAt: timestamp('modifiedAt').notNull().defaultNow()
 });
 
-export const events = pgTable('events', {
+export const eventSchema = pgTable('event', {
   event_id: serial('event_id').primaryKey().notNull(),
   body: jsonb('body').notNull(),
   createdAt: timestamp('createdAt').notNull().defaultNow()


### PR DESCRIPTION
In refactoring the reference-azure-backend to write to Azure SQL, we made the decision to update all table references from plural to singular in accordance with database table naming conventions. Each row now represents a single occurrence of the modeled entity.

*Note*: In the Azure SQL case, simply starting the function app causes TypeORM to create the schema if not already present, which is why this create-sql script is just being updated now.

Documentation updates for this change are reflected in #100.