### PR TITLE
Token refresh: re-Initialize data source rather than change token metadata

### DIFF
--- a/reference-azure-backend/functions/src/index.ts
+++ b/reference-azure-backend/functions/src/index.ts
@@ -22,8 +22,7 @@ app.hook.appStart(async (context: AppStartContext) => {
 
 app.hook.preInvocation(async (context: PreInvocationContext) => {
     if (!cachedToken || !tokenExpiration || tokenExpiration <= Date.now()) {
-        const token = await getToken();
-        dataSource.options.extra.authentication.options.token = token;
+       await initializeDataSource();
     }
 });
 


### PR DESCRIPTION
TypeORM data sources do not appear to be configurable after initialization. Therefore, we need to re-initialize the data source with every token refresh.