### PR TITLE
Fixing new citation bug

### DIFF
--- a/client/src/State.ts
+++ b/client/src/State.ts
@@ -489,10 +489,12 @@ const stateAtom = atom<State, [Action], void>(
                       docFromId[ux.documentId!].di
                     );
 
+                    const citationId = createCitationId(metadata.formId, "client");
+
                     selectCitation(
                       questions[ux.questionIndex].citations.push({
                         documentId: ux.documentId!,
-                        citationId: createCitationId(metadata.formId, "client"),
+                        citationId: citationId,
                         bounds,
                         excerpt,
                         review: Review.Unreviewed,
@@ -505,7 +507,7 @@ const stateAtom = atom<State, [Action], void>(
                         formId: metadata.formId,
                         questionId: questions[ux.questionIndex].questionId,
                         documentId: ux.documentId!,
-                        citationId: createCitationId(metadata.formId, "client"),
+                        citationId: citationId,
                         excerpt,
                         bounds,
                         review: Review.Approved,

--- a/local-backend/README.md
+++ b/local-backend/README.md
@@ -27,3 +27,5 @@ deno task dev
 ```
 
 If you use VS Code, you'll probably want to install and enable the [Deno plugin](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno).
+
+For instructions on debugging, see [here](https://docs.deno.com/runtime/fundamentals/debugging/#example-with-chrome-devtools).

--- a/local-backend/deno.json
+++ b/local-backend/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --allow-net --allow-read --watch server.ts",
+    "dev": "deno run --allow-net --allow-read --watch --inspect server.ts",
     "run": "deno run --allow-net --allow-read server.ts"
   },
   "imports": {


### PR DESCRIPTION
Fixes a bug when adding new citations where the citationId was different between the frontend UI and backend database because it's using system time and sometimes it'd be off by 1 since we're calling the createId twice in a row instead of just once.

Also adds a debugger to the backend deno.