### PR TITLE
Implement exact match search algorithm

### DIFF
--- a/client/src/Utility.ts
+++ b/client/src/Utility.ts
@@ -8,7 +8,7 @@ import {
   Word,
   excerptToSummary,
   flattenPolygon4,
-  combinePolygons,
+  combinePolygons
 } from "./di";
 
 interface Column {

--- a/client/src/di/DI.ts
+++ b/client/src/di/DI.ts
@@ -17,7 +17,7 @@ import {
   flattenPolygon4,
   isSameOrAdjacentParagraph,
 } from "./Utility";
-import { offsetSearch } from "./OffsetSearch";
+import { wordOffsetSearch } from "./OffsetSearch";
 
 /**
  * Creates a summary from a specified range of words across one or more pages.
@@ -323,7 +323,7 @@ function offsetBasedExcerpt(excerpt: string, di: DocIntResponse): Summary {
  * @param di - The document interpretation response containing analyzed text.
  * @returns A tuple `[pageIndex, wordIndex]` if found, otherwise `null`.
  */
-function findWordByOffset(
+export function findWordByOffset(
   offset: number,
   di: DocIntResponse
 ): [number, number] | null {
@@ -332,9 +332,9 @@ function findWordByOffset(
     const page = pages[pageIndex];
     if (!page.words || page.words.length === 0) continue;
 
-    const match = offsetSearch(page.words, [offset, offset]);
-    if (match) {
-      return [pageIndex, match[0]];
+    const wordId = wordOffsetSearch(page.words, offset);
+    if (wordId !== -1) {
+      return [pageIndex, wordId];
     }
   }
   return null;

--- a/client/src/di/OffsetSearch.ts
+++ b/client/src/di/OffsetSearch.ts
@@ -115,3 +115,23 @@ function offsetBinarySearch(
 export function offsetSearch(words: Word[], offsetRange: Range): Range | null {
   return offsetBinarySearch(words, [0, words.length], offsetRange);
 }
+
+/**
+ * Searches for the word in the array that contains the given offset.
+ *
+ * @param words - The array of words to search through.
+ * @param offset - The text offset to find within the words.
+ * @returns The index of the word that contains the offset, or -1 if not found.
+ */
+export function wordOffsetSearch(words: Word[], offset: number): number {
+  for (let i = 0; i < words.length; i++) {
+
+    const start = words[i].span.offset;
+    const end = start + words[i].span.length;
+
+    if (offset >= start && offset < end) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/client/src/di/Types.ts
+++ b/client/src/di/Types.ts
@@ -296,3 +296,13 @@ interface Span {
   offset: number;
   length: number;
 }
+
+/**
+ * Represents a search result segment, including the text, page number,
+ * and associated bounding regions.
+ */
+export interface SearchResultSegment {
+  text: string;
+  page: number;
+  boundingRegions: PolygonC;
+}

--- a/client/src/di/tests/unit/DI.test.ts
+++ b/client/src/di/tests/unit/DI.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
 import { createPerPageRegions } from "../../Preprocess";
 import { excerptToSummary, rangeToSummary } from "../../DI";
-import { CursorRange, DocIntResponse, Summary } from "../../Types";
+import { CursorRange, DocIntResponse, SearchResultSegment, Summary } from "../../Types";
+import { exactMatchSearch } from "../../Utility";
 
 import json0 from "../../../../../local-backend/files/PressReleaseFY24Q3.pdf.json";
 
@@ -319,4 +320,97 @@ excerptToSummaryTest(
   summary8.excerpt,
   di0,
   summary8
+);
+
+
+
+const exactMatchSearchTest = (
+  description: string,
+  input: string,
+  di: DocIntResponse,
+  expected: []
+) =>
+  test(`exactMatchSearchTest | ${description}`, () => {
+    const actual = exactMatchSearch(input, di);
+    expect(actual).toEqual(expected);
+  });
+
+  const input0 = "sadjfksajdh"
+  // expected should be a empty array
+  exactMatchSearchTest(
+   "the input should not be found in the document",
+    input0,
+    di0,
+    []
+  );
+
+  const input1 = "Microsoft Cloud Strength Fuels Third Quarter Results"
+  const searchResult1: SearchResultSegment = {
+    text: "Microsoft Cloud Strength Fuels Third Quarter Results",
+    page: 1,
+    boundingRegions: 
+    {
+      head: [0.9865, 1.0309, 5.5062, 1.0309, 5.5062, 1.2401, 0.9865, 1.2401],
+    },
+  };
+  
+  const expected1 = [{segments: [searchResult1], matchingRatio:1}];
+
+  exactMatchSearchTest(
+    "should find one exact match in the document",
+    input1,
+    di0,
+    expected1 as []
+  );
+
+const input2 = "Revenue in"
+const expected2 = [
+  {
+    segments: 
+    [
+      {
+      text: "Revenue in",
+      page: 1,
+      boundingRegions:
+      {
+        head: [0.9898, 4.9695, 1.65, 4.9695, 1.65, 5.1483, 0.9898, 5.1483],
+      }
+    } as SearchResultSegment,
+  ],
+    matchingRatio: 1
+  },
+  {
+    segments: 
+    [
+      {
+      text: "Revenue in",
+      page: 1,
+      boundingRegions:{
+        head: [0.9903, 7.1594, 1.6489, 7.1594, 1.6489, 7.3416, 0.9903, 7.3416],
+      }
+    } as SearchResultSegment,
+  ],
+    matchingRatio: 1
+  },
+  {
+    segments: 
+    [
+      {
+      text: "Revenue in",
+      page: 1,
+      boundingRegions:{
+        head: [0.989, 8.0757, 1.6541, 8.0757, 1.6541, 8.253, 0.989, 8.253],
+      }
+    } as SearchResultSegment,
+  ],
+    matchingRatio: 1
+  },
+];
+
+
+exactMatchSearchTest(
+  "should multi exact matches in the document",
+  input2,
+  di0,
+  expected2 as []
 );


### PR DESCRIPTION
This PR adds an exact match search algorithm that returns all instances of a given text input.
 
**Output:**
The following segments structure allows us to capture all instances and if they span pages.
```json
[
   # Instance 1
   {
      "segments": [
          # Segment 1
          {
            "pageNumber": "",
            "text": "",
            "boundingRegions": "",
          },
          # Segment 2
          ...
       ],
      "matchingRatio": ""
   },
   # Instance 2
   ...
]
```