### PR TITLE
add selection hover

### DIFF
--- a/client/src/Types.ts
+++ b/client/src/Types.ts
@@ -140,6 +140,9 @@ export type Action =
     end: Point;
   }
   | {
+    type: "endSelectionHover";
+  }
+  | {
     type: "endSelection";
   }
   | {
@@ -316,6 +319,7 @@ export interface SelectingNewCitationModeState extends BaseDocumentModeState {
   start: Point;
   excerpt?: string;
   bounds?: Bounds[];
+  hoverBounds?: Bounds[];
 }
 
 // Resizing an existing citation


### PR DESCRIPTION
now when the user clicks "add citation" and move the mouse around the page, they see a rectangle over the current word, as feedback about where their selection would start if they moused down.